### PR TITLE
Remote discriminator mention

### DIFF
--- a/linking.json
+++ b/linking.json
@@ -11,11 +11,11 @@
     "fields": [
       {
         "name": ":link: Linking your Spigot account.",
-        "value": "`1.` - Under your [contact details](https://www.spigotmc.org/account/contact-details) on Spigot set your Discord to your full Discord name, ie `md_5#0001`\n\n`2.` - Be sure to check your privacy settings and allow people to see your contact details or else we won't see it.\n\n`3.` - Type `/spigot verify` and paste your profile url"
+        "value": "`1.` - Under your [contact details](https://www.spigotmc.org/account/contact-details) on Spigot set your Discord to your full Discord name, ie `md_5`\n\n`2.` - Be sure to check your privacy settings and allow people to see your contact details or else we won't see it.\n\n`3.` - Type `/spigot verify` and paste your profile url"
       },
       {
         "name": ":question: Unable to link your account?",
-        "value": "Here's some troubleshooting steps to check:\n\n• Come back later! Your info was probably cached without the id. \n\n• Check your spigot privacy settings so non-members can see your contact details.\n\n• Check your discord is spelt correctly and contains your discriminator ie. `#0001`\n\n• Your profile url is found under your username [profile page](https://i.imgur.com/iz1MdTJ.png). :arrow_down:"
+        "value": "Here's some troubleshooting steps to check:\n\n• Come back later! Your info was probably cached without the id. \n\n• Check your spigot privacy settings so non-members can see your contact details.\n\n• Check your discord is spelt correctly.\n\n• Your profile url is found under your username [profile page](https://i.imgur.com/iz1MdTJ.png). :arrow_down:"
       }
     ]
   }


### PR DESCRIPTION
Discord usernames no longer are in the `name#discrim` format and instead unique, so this should be reflected in the instructions.